### PR TITLE
Defined empty value for lookup key

### DIFF
--- a/src/main/resources/org/sonar/l10n/widgetlab.properties
+++ b/src/main/resources/org/sonar/l10n/widgetlab.properties
@@ -5,6 +5,7 @@ widget.rules-alt.description=Shows weighted issues, in addition to Rules Complia
 widget.rules-alt.total.suffix=Total
 widget.rules-alt.title=Weighted Issues
 widget.rules.rules_compliance=Rules Compliance
+widget.rules.technical_debt.days=
 
 widget.manual_severity_reviews.name=Manual Severity Reviews
 widget.manual_severity_reviews.description=Shows reviews with a manual severity.


### PR DESCRIPTION
Added an empty string definition to avoid displaying the lookup key (using SonarQube 4.3).