### PR TITLE
Remove multi-threading and error-handling from tags matched on by Security widgets.

### DIFF
--- a/src/main/resources/security_issues_tag_global_widget.html.erb
+++ b/src/main/resources/security_issues_tag_global_widget.html.erb
@@ -20,7 +20,7 @@
                   "owasp-a1", "owasp-a2", "owasp-a3", "owasp-a4", "owasp-a5",
                   "owasp-a6", "owasp-a7", "owasp-a8", "owasp-a9", "owasp-a10",
                   "sans-top25-insecure", "sans-top25-porous", "sans-top25-risky",
-                  "error-handling", "multi-threading","injection", "denial-of-service"];
+                  "injection", "denial-of-service"];
 
     var queryParams = [
           'ps=1',

--- a/src/main/resources/security_issues_tag_widget.html.erb
+++ b/src/main/resources/security_issues_tag_widget.html.erb
@@ -34,7 +34,7 @@
                   "owasp-a1", "owasp-a2", "owasp-a3", "owasp-a4", "owasp-a5",
                   "owasp-a6", "owasp-a7", "owasp-a8", "owasp-a9", "owasp-a10",
                   "sans-top25-insecure", "sans-top25-porous", "sans-top25-risky",
-                  "error-handling", "multi-threading","injection", "denial-of-service"];
+                  "injection", "denial-of-service"];
 
     var createdAfter = '';
     <% if @dashboard_configuration.selected_period? -%>


### PR DESCRIPTION
Remove multi-threading from tags to be included by these widgets because multi-threading is more of a quality/performance issue, than a security specific issue. Remove exception handling for the same reason. It's a general quality concern not a security specific issue. In my experience, including exception handling issues in these widgets tends to overwhelm the rest of the issues the widgets report because there usually are way more exception handling issues than true security issues.

If you don't want to remove one or both of these, then make the widget's configurable so a customer can removed them if they want to. But I think they should simply be removed, particularly multi-threading.
